### PR TITLE
Fix loop not stopping when clicking looping sound

### DIFF
--- a/soundboard.js
+++ b/soundboard.js
@@ -438,6 +438,10 @@ class SoundBoard {
 
     static stopLoop(identifyingPath) {
         SoundBoard.getSoundFromIdentifyingPath(identifyingPath).loop = false;
+
+        // We clear the intervals otherwise a loop with delay will play one last time after the loop has been stopped
+        SoundBoard.audioHelper.delayIntervals.clear(identifyingPath);
+
         $('#soundboard-app .btn').filter(`[uuid=${$.escapeSelector(identifyingPath)}]`).removeClass('loop-active');
     }
 


### PR DESCRIPTION
When clicking on a sound's three dots, then on the loop icon, the sound will begin to play in a loop. Click again on the sound, and it should stop playing, but it doesn't.

I believe this happened because Foundry doesn't trigger an "end" event on a looping sound, so that event listener was never called. By handling the loop ourselves, this issue no longer happens. It does, however, cause an issue with Loops with delays. Without the modification to the delayIntervals, the sound would play once more after the loop is stopped.

Also, thank you for fixing the module for v12. I used it a while ago, then stopped, and now needed it again only to find it gone. Happy to see someone kept it working for now.